### PR TITLE
release 1.6.0

### DIFF
--- a/io.github.ctlcltd.e2se.yaml
+++ b/io.github.ctlcltd.e2se.yaml
@@ -23,5 +23,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/ctlcltd/e2-sat-editor.git
-        tag: v1.5.0
-        commit: a3b4075a6f39db77e359bdbab2398a83900d65e0
+        tag: v1.6.0
+        commit: 7893daa6fb64a519babaf6aed470ba59e7787b6e


### PR DESCRIPTION
- Fix crash with empty service parameters on save
- Fix parental lock on write
- Fix a buffer overflow when parsing userbouquet service flag
- Added support for 519 bouquet hidden
- Fix soft errors when listing with FTP command NLST
- Added cross-platform support for CRLF end line on read
- Added button to calculate DVBNS transponder
- Improved merge
- Updated translations